### PR TITLE
ENH: Add -d/--developer option to qSlicerCommandOptions

### DIFF
--- a/Base/QTGUI/qSlicerCommandOptions.cxx
+++ b/Base/QTGUI/qSlicerCommandOptions.cxx
@@ -66,6 +66,12 @@ bool qSlicerCommandOptions::enableQtTesting()const
 }
 
 //-----------------------------------------------------------------------------
+bool qSlicerCommandOptions::developerMode() const
+{
+  return this->parsedArgs().value("developer").toBool();
+}
+
+//-----------------------------------------------------------------------------
 void qSlicerCommandOptions::addArguments()
 {
   this->Superclass::addArguments();
@@ -78,6 +84,9 @@ void qSlicerCommandOptions::addArguments()
 
   this->addArgument("no-main-window", "", QVariant::Bool,
                     "Disables display of the main slicer window.  Use with --python-script for alternate interface");
+
+  this->addArgument("developer", "d", QVariant::Bool,
+                    "Enables the developer mode");
 
 #ifdef Slicer_USE_PYTHONQT
   if (!qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))

--- a/Base/QTGUI/qSlicerCommandOptions.cxx
+++ b/Base/QTGUI/qSlicerCommandOptions.cxx
@@ -66,9 +66,9 @@ bool qSlicerCommandOptions::enableQtTesting()const
 }
 
 //-----------------------------------------------------------------------------
-bool qSlicerCommandOptions::developerMode() const
+bool qSlicerCommandOptions::enableDeveloperFeatures() const
 {
-  return this->parsedArgs().value("developer").toBool();
+  return this->parsedArgs().value("enable-developer-features").toBool();
 }
 
 //-----------------------------------------------------------------------------
@@ -85,7 +85,7 @@ void qSlicerCommandOptions::addArguments()
   this->addArgument("no-main-window", "", QVariant::Bool,
                     "Disables display of the main slicer window.  Use with --python-script for alternate interface");
 
-  this->addArgument("developer", "d", QVariant::Bool,
+  this->addArgument("enable-developer-features", "d", QVariant::Bool,
                     "Enables the developer mode");
 
 #ifdef Slicer_USE_PYTHONQT

--- a/Base/QTGUI/qSlicerCommandOptions.h
+++ b/Base/QTGUI/qSlicerCommandOptions.h
@@ -36,7 +36,7 @@ class Q_SLICER_BASE_QTGUI_EXPORT qSlicerCommandOptions : public qSlicerCoreComma
   Q_PROPERTY(bool noMainWindow READ noMainWindow)
   Q_PROPERTY(bool showPythonInteractor READ showPythonInteractor)
   Q_PROPERTY(bool enableQtTesting READ enableQtTesting)
-  Q_PROPERTY(bool developerMode READ developerMode)
+  Q_PROPERTY(bool enableDeveloperFeatures READ enableDeveloperFeatures)
 public:
   typedef qSlicerCoreCommandOptions Superclass;
   qSlicerCommandOptions();
@@ -52,7 +52,7 @@ public:
 
   bool enableQtTesting()const;
 
-  bool developerMode()const;
+  bool enableDeveloperFeatures()const;
 
 protected:
   virtual void addArguments();

--- a/Base/QTGUI/qSlicerCommandOptions.h
+++ b/Base/QTGUI/qSlicerCommandOptions.h
@@ -36,6 +36,7 @@ class Q_SLICER_BASE_QTGUI_EXPORT qSlicerCommandOptions : public qSlicerCoreComma
   Q_PROPERTY(bool noMainWindow READ noMainWindow)
   Q_PROPERTY(bool showPythonInteractor READ showPythonInteractor)
   Q_PROPERTY(bool enableQtTesting READ enableQtTesting)
+  Q_PROPERTY(bool developerMode READ developerMode)
 public:
   typedef qSlicerCoreCommandOptions Superclass;
   qSlicerCommandOptions();
@@ -50,6 +51,8 @@ public:
   bool showPythonInteractor()const;
 
   bool enableQtTesting()const;
+
+  bool developerMode()const;
 
 protected:
   virtual void addArguments();


### PR DESCRIPTION
This allows VesselView to launch in developer mode.
