### PR TITLE
COMP: Make sure to set ITK_NO_IO_FACTORY_REGISTER_MANAGER to 1 for MetaI...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -728,6 +728,7 @@ endif()
 # ITK
 #-----------------------------------------------------------------------------
 find_package(ITK REQUIRED)
+set( ITK_NO_IO_FACTORY_REGISTER_MANAGER 1 ) # See Libs/ITKFactoryRegistration/CMakeLists.txt
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
...O hack

Because of 62c5a9b5eb137b19399b5eca0ac90ec43298db1b, we need to be careful
and set the ITK_NO_IO_FACTORY_REGISTER_MANAGER variable to 1 before
including ITK.
